### PR TITLE
Fix silent-error deprecation.

### DIFF
--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -11,6 +11,8 @@ var nopt      = require('nopt');
 var RSVP      = require('rsvp');
 var Command   = require('ember-cli/lib/models/command');
 
+var SilentError = require('silent-error');
+
 var resolve = RSVP.resolve;
 var resolveAll = RSVP.all;
 
@@ -149,7 +151,6 @@ var ReleaseCommand = Command.extend({
     date: require('../strategies/date')
   },
   run: function(cliOptions) {
-    var SilentError = this.project.require('ember-cli/lib/errors/silent');
     var ui = this.ui;
     var project = this.project;
     var projectRoot = project.root;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "moment-timezone": "^0.3.0",
     "nopt": "^3.0.3",
     "rsvp": "^3.0.17",
-    "semver": "^4.3.1"
+    "semver": "^4.3.1",
+    "silent-error": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^2.1.1",


### PR DESCRIPTION
The internal `SilentError` that we were getting from ember-cli itself, has been extracted into another package (for easier sharing). The old path is still around but prints a deprecation warning when accessed.

This updates our internal usage to the new package and fixes the deprecation.