### PR TITLE
Add a newline when rewriting package.json

### DIFF
--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -246,7 +246,7 @@ var ReleaseCommand = Command.extend({
             // Don't use the 'v' tag prefix for manifest file versions
             pkg.version = tagPrefix.strip(nextVersion);
 
-            var contents = JSON.stringify(pkg, null, 2);
+            var contents = JSON.stringify(pkg, null, 2) + '\n';
 
             fs.writeFileSync(filepath, contents, {
               encoding: 'utf8'

--- a/tests/acceptance/commands/release-nodetest.js
+++ b/tests/acceptance/commands/release-nodetest.js
@@ -261,6 +261,20 @@ describe("release command", function() {
             });
           });
 
+          it("should ensure package.json is normalized with a trailing newline", function() {
+            copyFixture('project-with-config');
+            var cmd = createCommand();
+
+            repo.respondTo('createTag', makeResponder(null));
+
+            return cmd.validateAndRun([ '--local', '--yes' ]).then(function() {
+              var pkgSource = fs.readFileSync('./package.json', { encoding: 'utf8' });
+
+              expect(pkgSource[pkgSource.length - 2]).to.equal('}');
+              expect(pkgSource[pkgSource.length - 1]).to.equal('\n');
+            });
+          });
+
           it("should use the tag name specified by the --tag option", function() {
             var createdTagName, createdTagMessage;
             var cmd = createCommand();


### PR DESCRIPTION
Closes #21.

This aligns ember-cli-release with the package.json normalization done by `npm install --save some-dep` as seen [here](https://github.com/npm/npm/blob/064d62c2f251cb5e9328f63228f711844b7a1787/lib/install/update-package-json.js#L15).