### PR TITLE
Upgrade Ember-CLI & Ember-CLI-Dependency-Checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "Steven Lindberg <steven@lytics.io>",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/lytics/ember-cli-release/issues"
+  },
   "dependencies": {
     "chalk": "^1.0.0",
     "git-tools": "^0.1.4",
@@ -30,8 +33,8 @@
   },
   "devDependencies": {
     "chai": "^2.1.1",
-    "ember-cli": "0.2.0",
-    "ember-cli-dependency-checker": "0.0.8",
+    "ember-cli": "1.13.8",
+    "ember-cli-dependency-checker": "1.1.0",
     "fs-extra": "^0.18.0",
     "glob": "^5.0.1",
     "mocha": "^2.2.1",

--- a/tests/acceptance/commands/release-nodetest.js
+++ b/tests/acceptance/commands/release-nodetest.js
@@ -53,6 +53,9 @@ describe("release command", function() {
           throw new Error('Module not found (fake implementation)');
         }
       },
+      hasDependencies: function () {
+        return true;
+      },
       isEmberCLIProject: function(){
         return true;
       }


### PR DESCRIPTION
Fix test to add `hasDependencies` to mock project object.