### PR TITLE
Fix ember deprecation warning

### DIFF
--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -393,6 +393,7 @@ module.exports = {
 
   // Merge options specified on the command line with those defined in the config
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     var baseOptions = this.baseOptions();
     var optionsFromConfig = this.config().options;
     var mergedOptions = baseOptions.map(function(availableOption) {


### PR DESCRIPTION
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `release`